### PR TITLE
Parse html attributes

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1,4 +1,5 @@
 import { type Token, Tokenizer } from "@/Tokenizer";
+import { aT } from "vitest/dist/reporters-MmQN-57K.js";
 
 export class Parser {
   private lookahead: Token | null = null;
@@ -42,14 +43,25 @@ export class Parser {
     return this.TwigBlock();
   }
 
-  private HTMLTag(): { type: string; name: string; body: any[] } {
+  private HTMLTag(): {
+    type: string;
+    name: string;
+    body: any[];
+    attributes: ReturnType<Parser["HTMLAttribute"]>[];
+  } {
     const isSelfClosingTag = this.lookahead?.type === "HTML_SELF_CLOSING_TAG";
     if (isSelfClosingTag) {
       const token = this.eat("HTML_SELF_CLOSING_TAG");
 
+      const name = /\w+/.exec(token.value)![0];
+      const attributes = [token.value.slice(1 + name.length, -2).trim()]
+        .filter((attribute) => Boolean(attribute))
+        .map((attribute) => this.HTMLAttribute());
+
       return {
         type: "HTMLTag",
         name: /\w+/.exec(token.value)![0],
+        attributes,
         body: [],
       };
     }
@@ -68,7 +80,15 @@ export class Parser {
     return {
       type: "HTMLTag",
       name: token.value.slice(1, -1),
+      attributes: [],
       body,
+    };
+  }
+
+  private HTMLAttribute() {
+    return {
+      type: "HTMLAttribute",
+      name: "disabled",
     };
   }
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -56,7 +56,7 @@ export class Parser {
       const name = /\w+/.exec(token.value)![0];
       const attributes = [token.value.slice(1 + name.length, -2).trim()]
         .filter((attribute) => Boolean(attribute))
-        .map((attribute) => this.HTMLAttribute());
+        .map((rawAttribute) => this.HTMLAttribute(rawAttribute));
 
       return {
         type: "HTMLTag",
@@ -67,6 +67,10 @@ export class Parser {
     }
 
     const token = this.eat("HTML_OPENING_TAG");
+    const name = /\w+/.exec(token.value)![0];
+    const attributes = [token.value.slice(1 + name.length, -1).trim()]
+      .filter((attribute) => Boolean(attribute))
+      .map((rawAttribute) => this.HTMLAttribute(rawAttribute));
 
     const body =
       // TODO: I think the lookahead is always defined so we don't
@@ -79,16 +83,16 @@ export class Parser {
 
     return {
       type: "HTMLTag",
-      name: token.value.slice(1, -1),
-      attributes: [],
+      name,
+      attributes,
       body,
     };
   }
 
-  private HTMLAttribute() {
+  private HTMLAttribute(rawAttribute: string) {
     return {
       type: "HTMLAttribute",
-      name: "disabled",
+      name: rawAttribute,
     };
   }
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -53,8 +53,10 @@ export class Parser {
       const token = this.eat("HTML_SELF_CLOSING_TAG");
 
       const name = /\w+/.exec(token.value)![0];
-      const attributes = [token.value.slice(1 + name.length, -2).trim()]
-        .filter((attribute) => Boolean(attribute))
+      const attributes = token.value
+        .slice(1 + name.length, -2)
+        .trim()
+        .split(/(?:(?<=["'])\s+|\s+(?=["'])|^|$)/)
         .map((rawAttribute) => this.HTMLAttribute(rawAttribute));
 
       return {
@@ -67,8 +69,10 @@ export class Parser {
 
     const token = this.eat("HTML_OPENING_TAG");
     const name = /\w+/.exec(token.value)![0];
-    const attributes = [token.value.slice(1 + name.length, -1).trim()]
-      .filter((attribute) => Boolean(attribute))
+    const attributes = token.value
+      .slice(1 + name.length, -1)
+      .trim()
+      .split(/(?:(?<=["'])\s+|\s+(?=["'])|^|$)/)
       .map((rawAttribute) => this.HTMLAttribute(rawAttribute));
 
     const body =

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1,5 +1,4 @@
 import { type Token, Tokenizer } from "@/Tokenizer";
-import { aT } from "vitest/dist/reporters-MmQN-57K.js";
 
 export class Parser {
   private lookahead: Token | null = null;

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -90,9 +90,20 @@ export class Parser {
   }
 
   private HTMLAttribute(rawAttribute: string) {
+    const hasValue = rawAttribute.includes("=");
+    const name = hasValue ? rawAttribute.split("=")[0] : rawAttribute;
+
+    if (hasValue) {
+      return {
+        type: "HTMLAttribute",
+        name,
+        value: rawAttribute.split("=")[1]!.slice(1, -1),
+      };
+    }
+
     return {
       type: "HTMLAttribute",
-      name: rawAttribute,
+      name,
     };
   }
 

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -10,7 +10,7 @@ const spec: Array<[RegExp, null | string]> = [
   // 3. HTML syntax
   [/^<\w+>/, "HTML_OPENING_TAG"],
   [/^<\/\w+>/, "HTML_CLOSING_TAG"],
-  [/^<\w+\s*\/>/, "HTML_SELF_CLOSING_TAG"],
+  [/^<\w+\s*([\w-]+\s*)*\s*\/>/, "HTML_SELF_CLOSING_TAG"],
 
   // 4. Literal values
   [/^\S+/, "LITERAL"],

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -8,9 +8,9 @@ const spec: Array<[RegExp, null | string]> = [
   [/^{% endblock %}/, "TWIG_END_BLOCK"],
 
   // 3. HTML syntax
-  [/^<\w+\s*([\w-]+\s*)*\s*>/, "HTML_OPENING_TAG"],
+  [/^<\w+\s*([\w\-="\w]+\s*)*\s*>/, "HTML_OPENING_TAG"],
   [/^<\/\w+>/, "HTML_CLOSING_TAG"],
-  [/^<\w+\s*([\w-]+\s*)*\s*\/>/, "HTML_SELF_CLOSING_TAG"],
+  [/^<\w+\s*([\w\-="\w]+\s*)*\s*\s\/>/, "HTML_SELF_CLOSING_TAG"],
 
   // 4. Literal values
   [/^\S+/, "LITERAL"],

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -8,7 +8,7 @@ const spec: Array<[RegExp, null | string]> = [
   [/^{% endblock %}/, "TWIG_END_BLOCK"],
 
   // 3. HTML syntax
-  [/^<\w+>/, "HTML_OPENING_TAG"],
+  [/^<\w+\s*([\w-]+\s*)*\s*>/, "HTML_OPENING_TAG"],
   [/^<\/\w+>/, "HTML_CLOSING_TAG"],
   [/^<\w+\s*([\w-]+\s*)*\s*\/>/, "HTML_SELF_CLOSING_TAG"],
 

--- a/tests/html.test.ts
+++ b/tests/html.test.ts
@@ -18,6 +18,7 @@ test("parses an HTML tag", () => {
         type: "HTMLTag",
         name: "div",
         body: [],
+        attributes: [],
       },
     ],
   });
@@ -42,11 +43,13 @@ test("parses adjacent HTML tags", () => {
         type: "HTMLTag",
         name: "div",
         body: [],
+        attributes: [],
       },
       {
         type: "HTMLTag",
         name: "div",
         body: [],
+        attributes: [],
       },
     ],
   });
@@ -67,11 +70,13 @@ test("parses nested HTML tags", () => {
       {
         type: "HTMLTag",
         name: "div",
+        attributes: [],
         body: [
           {
             type: "HTMLTag",
             name: "div",
             body: [],
+            attributes: [],
           },
         ],
       },
@@ -94,6 +99,34 @@ test("parses self-closing HTML tag", () => {
       {
         type: "HTMLTag",
         name: "input",
+        body: [],
+        attributes: [],
+      },
+    ],
+  });
+});
+
+test("parses HTML tag with an attribute", () => {
+  // GIVEN
+  const program = "<input disabled />";
+  const subject = new Parser(new Tokenizer());
+
+  // WHEN
+  const result = subject.parse(program);
+
+  // THEN
+  expect(result).toStrictEqual({
+    type: "Program",
+    body: [
+      {
+        type: "HTMLTag",
+        name: "input",
+        attributes: [
+          {
+            type: "HTMLAttribute",
+            name: "disabled",
+          },
+        ],
         body: [],
       },
     ],

--- a/tests/html.test.ts
+++ b/tests/html.test.ts
@@ -159,3 +159,31 @@ test("parses HTML tag with an attribute", () => {
     ],
   });
 });
+
+test("parses HTML attribute with a value", () => {
+  // GIVEN
+  const program = '<div class="my-class"></div>';
+  const subject = new Parser(new Tokenizer());
+
+  // WHEN
+  const result = subject.parse(program);
+
+  // THEN
+  expect(result).toStrictEqual({
+    type: "Program",
+    body: [
+      {
+        type: "HTMLTag",
+        name: "div",
+        attributes: [
+          {
+            type: "HTMLAttribute",
+            name: "class",
+            value: "my-class",
+          },
+        ],
+        body: [],
+      },
+    ],
+  });
+});

--- a/tests/html.test.ts
+++ b/tests/html.test.ts
@@ -106,7 +106,7 @@ test("parses self-closing HTML tag", () => {
   });
 });
 
-test("parses HTML tag with an attribute", () => {
+test("parses self-closing HTML tag with an attribute", () => {
   // GIVEN
   const program = "<input disabled />";
   const subject = new Parser(new Tokenizer());
@@ -125,6 +125,33 @@ test("parses HTML tag with an attribute", () => {
           {
             type: "HTMLAttribute",
             name: "disabled",
+          },
+        ],
+        body: [],
+      },
+    ],
+  });
+});
+
+test("parses HTML tag with an attribute", () => {
+  // GIVEN
+  const program = "<div hidden></div>";
+  const subject = new Parser(new Tokenizer());
+
+  // WHEN
+  const result = subject.parse(program);
+
+  // THEN
+  expect(result).toStrictEqual({
+    type: "Program",
+    body: [
+      {
+        type: "HTMLTag",
+        name: "div",
+        attributes: [
+          {
+            type: "HTMLAttribute",
+            name: "hidden",
           },
         ],
         body: [],

--- a/tests/html.test.ts
+++ b/tests/html.test.ts
@@ -187,3 +187,40 @@ test("parses HTML attribute with a value", () => {
     ],
   });
 });
+
+test("parse HTML tag with multiple attributes", () => {
+  // GIVEN
+  const program = '<button class="my-class" id="my-id" disabled></button>';
+  const subject = new Parser(new Tokenizer());
+
+  // WHEN
+  const result = subject.parse(program);
+
+  // THEN
+  expect(result).toStrictEqual({
+    type: "Program",
+    body: [
+      {
+        type: "HTMLTag",
+        name: "button",
+        attributes: [
+          {
+            type: "HTMLAttribute",
+            name: "class",
+            value: "my-class",
+          },
+          {
+            type: "HTMLAttribute",
+            name: "id",
+            value: "my-id",
+          },
+          {
+            type: "HTMLAttribute",
+            name: "disabled",
+          },
+        ],
+        body: [],
+      },
+    ],
+  });
+});

--- a/tests/mixed.test.ts
+++ b/tests/mixed.test.ts
@@ -26,6 +26,7 @@ test("parses an HTML tag inside a Twig block", () => {
             type: "HTMLTag",
             name: "div",
             body: [],
+            attributes: [],
           },
         ],
       },
@@ -52,6 +53,7 @@ test("parses HTML tag adjacent to Twig block", () => {
         type: "HTMLTag",
         name: "div",
         body: [],
+        attributes: [],
       },
       {
         type: "TwigBlock",


### PR DESCRIPTION
## What?

This PR allows the parser to parse HTML tags with attributes.

## Why?

HTML offers the possibility to add attributes to a tag.

## How?

The parser extracts out the attributes from the tokenised HTML tag.

## Testing?

Automated tests should be enough.
