### PR TITLE
feat: ignore <!DOCTYPE html> in files

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -2,6 +2,7 @@ const spec: Array<[RegExp, null | string]> = [
   // 1. Stuff we ignore
   [/^\s+/, null],
   [/^<!--.*-->/, null],
+  [/^<!DOCTYPE html>/, null],
 
   // 2. Twig Syntax
   [/^{% block \w+ %}/, "TWIG_START_BLOCK"],

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -16,3 +16,18 @@ test("parses an empty file", () => {
     body: [],
   });
 });
+
+test("ignores the <!DOCTYPE> tag", () => {
+  // GIVEN
+  const program = "<!DOCTYPE html>";
+  const subject = new Parser(new Tokenizer());
+
+  // WHEN
+  const result = subject.parse(program);
+
+  // THEN
+  expect(result).toStrictEqual({
+    type: "Program",
+    body: [],
+  });
+});


### PR DESCRIPTION
## What?

The parser should, for now, ignore the doctype tag.

## Why?

There are two reasons.

1. Adding this allows us to parse html files containing the doctype tag without throwing an error
2. As of now we don't see any value in actually adding that information in an AST

## How?

I added `<!DOCTYPE html>` to the list of ignored tokens.

## Testing?

Run the unit tests.