### PR TITLE
Parse raw text

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -16,18 +16,33 @@ export class Parser {
   private Program() {
     return {
       type: "Program",
-      body: this.TagList(),
+      body: this.NodeList(),
     };
   }
 
-  private TagList(options: { stopAt: string } | undefined = undefined) {
-    const tags = [];
+  private NodeList(options: { stopAt: string } | undefined = undefined) {
+    const nodes = [];
 
     while (this.lookahead !== null && this.lookahead.type !== options?.stopAt) {
-      tags.push(this.Tag());
+      switch (this.lookahead.type) {
+        case "TEXT":
+          nodes.push(this.Text());
+          break;
+        default:
+          nodes.push(this.Tag());
+      }
     }
 
-    return tags;
+    return nodes;
+  }
+
+  private Text() {
+    const { value } = this.eat("TEXT");
+
+    return {
+      type: "Text",
+      value,
+    };
   }
 
   private Tag() {
@@ -79,7 +94,7 @@ export class Parser {
       // TODO: I think the lookahead is always defined so we don't
       //  need the optional chaining operator
       this.lookahead?.type !== "HTML_CLOSING_TAG"
-        ? this.TagList({ stopAt: "HTML_CLOSING_TAG" })
+        ? this.NodeList({ stopAt: "HTML_CLOSING_TAG" })
         : [];
 
     this.eat("HTML_CLOSING_TAG");
@@ -115,7 +130,7 @@ export class Parser {
 
     const body =
       this.lookahead?.type !== "TWIG_END_BLOCK"
-        ? this.TagList({ stopAt: "TWIG_END_BLOCK" })
+        ? this.NodeList({ stopAt: "TWIG_END_BLOCK" })
         : [];
 
     this.eat("TWIG_END_BLOCK");

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -14,7 +14,7 @@ const spec: Array<[RegExp, null | string]> = [
   [/^<\w+\s*([\w\-="\w]+\s*)*\s*\s\/>/, "HTML_SELF_CLOSING_TAG"],
 
   // 4. Literal values
-  [/^\S+/, "LITERAL"],
+  [/^[\d\w\s\!\?\=\_\,]+/, "TEXT"],
 ];
 
 export type Token = {

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -14,7 +14,7 @@ const spec: Array<[RegExp, null | string]> = [
   [/^<\w+\s*([\w\-="\w]+\s*)*\s*\s\/>/, "HTML_SELF_CLOSING_TAG"],
 
   // 4. Literal values
-  [/^[\d\w\s\!\?\=\_\,]+/, "TEXT"],
+  [/^[\d\w\s\!\?\=\_\,]+\b(!|\?)*/, "TEXT"],
 ];
 
 export type Token = {

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -17,6 +17,26 @@ test("parses an empty file", () => {
   });
 });
 
+test("parses a file with raw text", () => {
+  // GIVEN
+  const program = "Hello, world!";
+  const subject = new Parser(new Tokenizer());
+
+  // WHEN
+  const result = subject.parse(program);
+
+  // THEN
+  expect(result).toStrictEqual({
+    type: "Program",
+    body: [
+      {
+        type: "Text",
+        value: "Hello, world!",
+      },
+    ],
+  });
+});
+
 test("ignores the <!DOCTYPE> tag", () => {
   // GIVEN
   const program = "<!DOCTYPE html>";

--- a/tests/html.test.ts
+++ b/tests/html.test.ts
@@ -224,3 +224,30 @@ test("parse HTML tag with multiple attributes", () => {
     ],
   });
 });
+
+test("parse text inside an HTML tag", () => {
+  // GIVEN
+  const program = "<p>Hello, world!</p>";
+  const subject = new Parser(new Tokenizer());
+
+  // WHEN
+  const result = subject.parse(program);
+
+  // THEN
+  expect(result).toStrictEqual({
+    type: "Program",
+    body: [
+      {
+        type: "HTMLTag",
+        name: "p",
+        attributes: [],
+        body: [
+          {
+            type: "Text",
+            value: "Hello, world!",
+          },
+        ],
+      },
+    ],
+  });
+});

--- a/tests/twig.test.ts
+++ b/tests/twig.test.ts
@@ -82,3 +82,29 @@ test("parse nested Twig blocks", () => {
     ],
   });
 });
+
+test("parses text inside a Twig block", () => {
+  // GIVEN
+  const program = "{% block my_block %} Hello, world! {% endblock %}";
+  const subject = new Parser(new Tokenizer());
+
+  // WHEN
+  const result = subject.parse(program);
+
+  // THEN
+  expect(result).toStrictEqual({
+    type: "Program",
+    body: [
+      {
+        type: "TwigBlock",
+        name: "my_block",
+        body: [
+          {
+            type: "Text",
+            value: "Hello, world!",
+          },
+        ],
+      },
+    ],
+  });
+});


### PR DESCRIPTION
## What?

Parse text globally, inside an Twig block and inside and HTML tag.

## Why?

This allows the parser to parse texts, that are shown to the user.

## How?

I adjusted how the tokeniser recognises text and updated the parser to reflect the new structure.

## Testing?

Either run the tests or re-create the scenarios explained the in _What?_ section.