### PR TITLE
refactor: parse html tag in smaller chunks

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -1,20 +1,33 @@
-const spec: Array<[RegExp, null | string]> = [
+const enum State {
+  Global = "GLOBAL",
+  InHTMLOpenTag = "IN_HTML_OPEN_TAG",
+  InHTMLClosingTag = "IN_HTML_CLOSING_TAG",
+}
+
+const spec: Array<[RegExp, null | string, State | null, State]> = [
   // 1. Stuff we ignore
-  [/^\s+/, null],
-  [/^<!--.*-->/, null],
-  [/^<!DOCTYPE html>/, null],
+  [/^\s+/, null, null, State.Global],
+  [/^<!--.*-->/, null, null, State.Global],
+  [/^<!DOCTYPE html>/, null, null, State.Global],
 
   // 2. Twig Syntax
-  [/^{% block \w+ %}/, "TWIG_START_BLOCK"],
-  [/^{% endblock %}/, "TWIG_END_BLOCK"],
+  [/^{% block \w+ %}/, "TWIG_START_BLOCK", null, State.Global],
+  [/^{% endblock %}/, "TWIG_END_BLOCK", null, State.Global],
 
   // 3. HTML syntax
-  [/^<\w+\s*([\w\-="\w]+\s*)*\s*>/, "HTML_OPENING_TAG"],
-  [/^<\/\w+>/, "HTML_CLOSING_TAG"],
-  [/^<\w+\s*([\w\-="\w]+\s*)*\s*\s\/>/, "HTML_SELF_CLOSING_TAG"],
+  [/^<\w+/, "START_OF_HTML_OPENING_TAG", State.InHTMLOpenTag, State.Global],
+  [/^\/>/, "END_OF_SELF_CLOSING_HTML_TAG", State.Global, State.Global],
+  [/^>/, "END_OF_HTML_TAG", State.Global, State.Global],
+  [
+    /^<\/\w+/,
+    "START_OF_HTML_CLOSING_TAG",
+    State.InHTMLClosingTag,
+    State.Global,
+  ],
+  [/^[\w-]+((="([^"]*)"))?/, "HTML_ATTRIBUTE", null, State.InHTMLOpenTag],
 
   // 4. Literal values
-  [/^[\d\w\s\!\?\=\_\,]+\b(!|\?)*/, "TEXT"],
+  [/^[\d\w\s\!\?\=\_\,]+\b(!|\?)*/, "TEXT", null, State.Global],
 ];
 
 export type Token = {
@@ -27,7 +40,10 @@ export type Token = {
  */
 export class Tokenizer {
   private cursor: number = 0;
+
   private string: string = "";
+
+  private state: State = State.Global;
 
   init(program: string) {
     this.string = program;
@@ -41,7 +57,13 @@ export class Tokenizer {
 
     const string = this.string.slice(this.cursor);
 
-    for (const [regex, type] of spec) {
+    for (const [regex, type, newStateAfterMatch, expectedState] of spec) {
+      // skip rule because it does not apply to the current context
+      const ruleDoesNotApplyToCurrentState =
+        expectedState !== State.Global && expectedState !== this.state;
+
+      if (ruleDoesNotApplyToCurrentState) continue;
+
       const tokenValue = this.match(regex, string);
 
       // Can't match this rule, try the next one.
@@ -49,6 +71,10 @@ export class Tokenizer {
 
       // skip token, e.g. whitespace
       if (type === null) return this.getNextToken();
+
+      // Now we have a match, define the state where the token will be in
+      // when it matches the upcoming token.
+      if (newStateAfterMatch) this.state = newStateAfterMatch;
 
       return {
         type,


### PR DESCRIPTION
## What?

The tokeniser and parser now handle html tags in smaller chunks. We first tokenise the html tag and then separately handle the html attributes, if they are some. Beforehand, we did both steps in one single step.

## Why?

It makes it easier for the parser to deal with HTML attributes.

## How?

By separating how we handle HTML tags and HTML attributes.

By splitting up the 

## Testing?

Unit tests should be enough.